### PR TITLE
chore: Fix release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,9 @@ builds:
 - env:
   - CGO_ENABLED=0
   main: ./cmd/manager/main.go
+  ignore:
+  - goos: darwin
+    goarch: "386"
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
Remove Darwin 386 distribution as support has been dropped with Go 1.14+